### PR TITLE
RA-172: Set container memory limit

### DIFF
--- a/plugin/src/main/resources/com/github/dump247/jenkins/plugins/dockerjob/slaves/create_slave.py
+++ b/plugin/src/main/resources/com/github/dump247/jenkins/plugins/dockerjob/slaves/create_slave.py
@@ -318,7 +318,8 @@ def main(args):
         'command': ['/bin/bash', install_dir + '/launch_slave.sh',
                     hash_file(slave_dir + '/init_slave.sh')],
         'volumes': [install_dir] + [v['container'] for v in options.volumes],
-        'environment': options.environment
+        'environment': options.environment,
+        'mem_limit': '2g'
     }
     start_opts = {
         'container': None,  # container id; set later


### PR DESCRIPTION
This sets the maximum memory a container is allowed to use when a slave is created