### PR TITLE
RA-176: Force Java8 JRE when launching `slave.jar`

### DIFF
--- a/plugin/src/main/resources/com/github/dump247/jenkins/plugins/dockerjob/slaves/init_host.sh
+++ b/plugin/src/main/resources/com/github/dump247/jenkins/plugins/dockerjob/slaves/init_host.sh
@@ -31,4 +31,5 @@ mkdir -p ${LAUNCH_DIR}/slave >/dev/null
 cat >${LAUNCH_DIR}/slave/properties.sh <<EOF
 CONNECT_ADDRESS=$(/sbin/ip addr show docker0 | grep -o 'inet [0-9]\+\.[0-9]\+\.[0-9]\+\.[0-9]\+' | grep -o [0-9].*)
 CONNECT_PORT=12112
+JDK_HOME=/usr/lib/jvm/jre-1.8.0-openjdk/
 EOF


### PR DESCRIPTION
Jenkins 2.X LTS now requires Java8 in order to run `slave.jar`. This change forces to always use Java8 JRE when launching slave.